### PR TITLE
Move things into lib from HA integration

### DIFF
--- a/src/wiim/__init__.py
+++ b/src/wiim/__init__.py
@@ -2,8 +2,12 @@
 """WiiM Asynchronous Python SDK."""
 
 from .__version__ import __version__
-from .wiim_device import WiimDevice
 from .controller import WiimController
+from .discovery import (
+    async_create_http_api_endpoint,
+    async_create_wiim_device,
+    verify_wiim_device,
+)
 from .endpoint import WiimApiEndpoint, WiimBaseEndpoint
 from .exceptions import (
     WiimException,
@@ -11,6 +15,7 @@ from .exceptions import (
     WiimInvalidDataException,
     WiimDeviceException,
 )
+from .wiim_device import WiimDevice
 from .consts import (
     PlayingStatus,
     PlayingMode,
@@ -35,6 +40,9 @@ __all__ = [
     "WiimController",
     "WiimApiEndpoint",
     "WiimBaseEndpoint",
+    "async_create_http_api_endpoint",
+    "async_create_wiim_device",
+    "verify_wiim_device",
     "WiimException",
     "WiimRequestException",
     "WiimInvalidDataException",

--- a/src/wiim/__init__.py
+++ b/src/wiim/__init__.py
@@ -18,6 +18,8 @@ from .exceptions import (
 from .models import (
     WiimLoopState,
     WiimMediaMetadata,
+    WiimGroupRole,
+    WiimGroupSnapshot,
     WiimPreset,
     WiimQueueItem,
     WiimQueueSnapshot,
@@ -58,6 +60,8 @@ __all__ = [
     "WiimDeviceException",
     "WiimLoopState",
     "WiimMediaMetadata",
+    "WiimGroupRole",
+    "WiimGroupSnapshot",
     "WiimPreset",
     "WiimQueueItem",
     "WiimQueueSnapshot",

--- a/src/wiim/__init__.py
+++ b/src/wiim/__init__.py
@@ -15,6 +15,7 @@ from .exceptions import (
     WiimInvalidDataException,
     WiimDeviceException,
 )
+from .models import WiimLoopState, WiimMediaMetadata, WiimRepeatMode
 from .wiim_device import WiimDevice
 from .consts import (
     PlayingStatus,
@@ -47,6 +48,9 @@ __all__ = [
     "WiimRequestException",
     "WiimInvalidDataException",
     "WiimDeviceException",
+    "WiimLoopState",
+    "WiimMediaMetadata",
+    "WiimRepeatMode",
     "PlayingStatus",
     "PlayingMode",
     "LoopMode",

--- a/src/wiim/__init__.py
+++ b/src/wiim/__init__.py
@@ -5,6 +5,7 @@ from .__version__ import __version__
 from .controller import WiimController
 from .discovery import (
     async_create_http_api_endpoint,
+    async_probe_wiim_device,
     async_create_wiim_device,
     verify_wiim_device,
 )
@@ -21,6 +22,7 @@ from .models import (
     WiimGroupRole,
     WiimGroupSnapshot,
     WiimPreset,
+    WiimProbeResult,
     WiimQueueItem,
     WiimQueueSnapshot,
     WiimRepeatMode,
@@ -52,6 +54,7 @@ __all__ = [
     "WiimApiEndpoint",
     "WiimBaseEndpoint",
     "async_create_http_api_endpoint",
+    "async_probe_wiim_device",
     "async_create_wiim_device",
     "verify_wiim_device",
     "WiimException",
@@ -63,6 +66,7 @@ __all__ = [
     "WiimGroupRole",
     "WiimGroupSnapshot",
     "WiimPreset",
+    "WiimProbeResult",
     "WiimQueueItem",
     "WiimQueueSnapshot",
     "WiimRepeatMode",

--- a/src/wiim/__init__.py
+++ b/src/wiim/__init__.py
@@ -15,7 +15,15 @@ from .exceptions import (
     WiimInvalidDataException,
     WiimDeviceException,
 )
-from .models import WiimLoopState, WiimMediaMetadata, WiimRepeatMode
+from .models import (
+    WiimLoopState,
+    WiimMediaMetadata,
+    WiimPreset,
+    WiimQueueItem,
+    WiimQueueSnapshot,
+    WiimRepeatMode,
+    WiimTransportCapabilities,
+)
 from .wiim_device import WiimDevice
 from .consts import (
     PlayingStatus,
@@ -50,7 +58,11 @@ __all__ = [
     "WiimDeviceException",
     "WiimLoopState",
     "WiimMediaMetadata",
+    "WiimPreset",
+    "WiimQueueItem",
+    "WiimQueueSnapshot",
     "WiimRepeatMode",
+    "WiimTransportCapabilities",
     "PlayingStatus",
     "PlayingMode",
     "LoopMode",

--- a/src/wiim/__main__.py
+++ b/src/wiim/__main__.py
@@ -10,6 +10,7 @@ from zeroconf.asyncio import AsyncServiceBrowser, AsyncZeroconf, Zeroconf
 from .consts import SDK_LOGGER
 from .controller import WiimController
 from .discovery import async_create_wiim_device
+from .exceptions import WiimDeviceException, WiimRequestException
 
 
 class ZeroconfListener:
@@ -98,14 +99,17 @@ async def main_cli():
 
             wiim_device = None
             for location in potential_locations:
-                wiim_device = await async_create_wiim_device(
-                    location,
-                    session,
-                    host=wiim_device_ip,
-                )
-                if wiim_device:
-                    SDK_LOGGER.info(f"Successfully verified WiiM device at {location}")
-                    break
+                try:
+                    wiim_device = await async_create_wiim_device(
+                        location,
+                        session,
+                        host=wiim_device_ip,
+                    )
+                except (WiimDeviceException, WiimRequestException):
+                    continue
+
+                SDK_LOGGER.info(f"Successfully verified WiiM device at {location}")
+                break
 
             if not wiim_device:
                 SDK_LOGGER.warning(

--- a/src/wiim/__main__.py
+++ b/src/wiim/__main__.py
@@ -3,15 +3,13 @@ import asyncio
 import logging
 from typing import Dict
 
-from aiohttp import ClientSession, TCPConnector
+from aiohttp import ClientSession
 from zeroconf import ServiceInfo
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncZeroconf, Zeroconf
 
 from .consts import SDK_LOGGER
 from .controller import WiimController
-from .discovery import verify_wiim_device
-from .endpoint import WiimApiEndpoint
-from .wiim_device import WiimDevice
+from .discovery import async_create_wiim_device
 
 
 class ZeroconfListener:
@@ -43,7 +41,7 @@ class ZeroconfListener:
 
 async def _create_cli_session() -> ClientSession:
     """Creates an aiohttp client session for the CLI."""
-    return ClientSession(connector=TCPConnector(ssl=False))
+    return ClientSession()
 
 
 async def main_cli():
@@ -98,39 +96,24 @@ async def main_cli():
                 f"http://{wiim_device_ip}:49152/description.xml",
             ]
 
-            upnp_device = None
+            wiim_device = None
             for location in potential_locations:
-                # Use the verify_wiim_device function from discovery.py to check if this is a WiiM device
-                upnp_device = await verify_wiim_device(location, session)
-                if upnp_device:
+                wiim_device = await async_create_wiim_device(
+                    location,
+                    session,
+                    host=wiim_device_ip,
+                )
+                if wiim_device:
                     SDK_LOGGER.info(f"Successfully verified WiiM device at {location}")
                     break
 
-            if not upnp_device:
+            if not wiim_device:
                 SDK_LOGGER.warning(
                     f"Could not verify device '{name}' at {wiim_device_ip}. It might not be a WiiM device or is not responding."
                 )
                 continue
 
-            # Create an HTTP API endpoint, using the WiiM device's IP
-            http_api = WiimApiEndpoint(
-                protocol="https", port=443, endpoint=wiim_device_ip, session=session
-            )
-
-            # Create and initialize the WiimDevice instance.
-            # Set ha_host_ip to the local IP address we just obtained.
-            wiim_dev = WiimDevice(
-                upnp_device,
-                session,
-                http_api_endpoint=http_api,
-                ha_host_ip=wiim_device_ip,
-                polling_interval=60,
-            )
-            await controller.add_device(wiim_dev)
-            # if await wiim_dev.async_init_services_and_subscribe():
-            #     await controller.add_device(wiim_dev)
-            # else:
-            #     SDK_LOGGER.warning(f"Failed to initialize WiimDevice after discovery: {upnp_device.friendly_name}")
+            await controller.add_device(wiim_device)
 
         if not controller.devices:
             SDK_LOGGER.info("No verifiable WiiM devices could be initialized.")

--- a/src/wiim/controller.py
+++ b/src/wiim/controller.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from typing import (
     TYPE_CHECKING,
     List,
-    Optional,
     Dict,
 )
 
@@ -30,9 +29,12 @@ class WiimController:
         self._event_callback = event_callback
         self.logger = SDK_LOGGER
 
-    def get_device(self, udn: str) -> WiimDevice | None:
+    def get_device(self, udn: str) -> WiimDevice:
         """Get a device by its UDN."""
-        return self._devices.get(udn)
+        try:
+            return self._devices[udn]
+        except KeyError as err:
+            raise ValueError(f"Device {udn} is not managed by the controller") from err
 
     @property
     def devices(self) -> List[WiimDevice]:
@@ -112,8 +114,7 @@ class WiimController:
                                 )
 
                                 if full_follower_udn:
-                                    follower_device = self.get_device(full_follower_udn)
-                                    if follower_device:
+                                    if full_follower_udn in self._devices:
                                         follower_udns.append(full_follower_udn)
                                     else:
                                         self.logger.warning(
@@ -216,22 +217,22 @@ class WiimController:
             self._multiroom_groups,
         )
 
-    def get_device_group_info(self, device_udn: str) -> Optional[Dict[str, str]]:
+    def get_device_group_info(self, device_udn: str) -> Dict[str, str]:
         """
         Get the group role (leader/follower/standalone) and leader UDN for a given device.
         Returns: {"role": "leader"|"follower"|"standalone", "leader_udn": leader's UDN}
         """
         snapshot = self.get_group_snapshot(device_udn)
-        if snapshot is None:
-            return None
 
         return {
             "role": snapshot.role.value,
             "leader_udn": snapshot.leader_udn,
         }
 
-    def get_group_snapshot(self, device_udn: str) -> WiimGroupSnapshot | None:
+    def get_group_snapshot(self, device_udn: str) -> WiimGroupSnapshot:
         """Return a typed multiroom snapshot for the given device."""
+        self.get_device(device_udn)
+
         if device_udn in self._multiroom_groups:
             follower_udns = tuple(self._multiroom_groups[device_udn])
             return WiimGroupSnapshot(
@@ -244,62 +245,35 @@ class WiimController:
             if device_udn in follower_udns:
                 return WiimGroupSnapshot(
                     role=WiimGroupRole.FOLLOWER,
-                    leader_udn=leader_udn,
-                    member_udns=(leader_udn, *tuple(follower_udns)),
-                )
-
-        if self.get_device(device_udn):
-            return WiimGroupSnapshot(
-                role=WiimGroupRole.STANDALONE,
-                leader_udn=device_udn,
-                member_udns=(device_udn,),
+                leader_udn=leader_udn,
+                member_udns=(leader_udn, *tuple(follower_udns)),
             )
 
-        return None
+        return WiimGroupSnapshot(
+            role=WiimGroupRole.STANDALONE,
+            leader_udn=device_udn,
+            member_udns=(device_udn,),
+        )
 
-    def get_command_target_udn(self, device_udn: str) -> str | None:
+    def get_command_target_udn(self, device_udn: str) -> str:
         """Return the device UDN that should receive direct commands."""
-        snapshot = self.get_group_snapshot(device_udn)
-        if snapshot is None:
-            return None
-        return snapshot.command_target_udn
+        return self.get_group_snapshot(device_udn).command_target_udn
 
     def get_group_members(self, device_udn: str) -> List[WiimDevice]:
         """
         Get all members of the group the given device belongs to (including itself).
         Returns a list of WiimDevice objects.
         """
-        leader_udn: Optional[str] = None
-        group_members_udns: List[str] = []
-
-        if device_udn in self._multiroom_groups:
-            leader_udn = device_udn
-            group_members_udns = [leader_udn] + self._multiroom_groups[leader_udn]
-        else:
-            for l_udn, f_udns in self._multiroom_groups.items():
-                if device_udn in f_udns:
-                    leader_udn = l_udn
-                    group_members_udns = [leader_udn] + f_udns
-                    break
-
-        if not group_members_udns:
-            device = self.get_device(device_udn)
-            return [device] if device else []
-
-        result_devices: List[WiimDevice] = []
-        for udn in set(group_members_udns):
-            device_obj = self.get_device(udn)
-            if device_obj:
-                result_devices.append(device_obj)
-        return result_devices
+        return [
+            self.get_device(member_udn)
+            for member_udn in self.get_group_snapshot(device_udn).member_udns
+        ]
 
     async def async_join_group(self, leader_udn: str, follower_udn: str) -> None:
         """Make follower_udn join the group led by leader_udn."""
         leader = self.get_device(leader_udn)
         follower = self.get_device(follower_udn)
 
-        if not leader or not follower:
-            raise WiimException("Leader or follower device not found.")
         if not leader._http_api or not follower._http_api:
             raise WiimException("HTTP API not available for leader or follower.")
 
@@ -350,14 +324,14 @@ class WiimController:
     async def async_ungroup_device(self, device_udn: str) -> None:
         """Make a device leave its current group. If it's a leader, the whole group is disbanded."""
         device = self.get_device(device_udn)
-        if not device or not device._http_api:
+        if not device._http_api:
             raise WiimException("Device not found or HTTP API unavailable.")
 
         group_info = self.get_device_group_info(device_udn)
         original_leader_to_update: WiimDevice | None = None
         self.logger.info("Gourp info %s, device uid = %s", group_info, device_udn)
 
-        if group_info and group_info.get("role") == "leader":
+        if group_info["role"] == "leader":
             self.logger.info(
                 "Ungrouping multiroom group led by %s (UDN: %s)",
                 device.name,
@@ -367,17 +341,9 @@ class WiimController:
             if device_udn in self._multiroom_groups:
                 del self._multiroom_groups[device_udn]
             original_leader_to_update = device
-        elif group_info and group_info.get("role") == "follower":
-            leader_udn_of_follower = group_info.get("leader_udn")
-            leader_of_this_device = None
-
-            if leader_udn_of_follower is not None:
-                leader_of_this_device = self.get_device(leader_udn_of_follower)
-
-            if not leader_of_this_device:
-                raise WiimException(
-                    f"Leader {leader_udn_of_follower} for follower {device.name} not found."
-                )
+        elif group_info["role"] == "follower":
+            leader_udn_of_follower = group_info["leader_udn"]
+            leader_of_this_device = self.get_device(leader_udn_of_follower)
             if not leader_of_this_device._http_api:
                 raise WiimException(
                     f"Leader {leader_of_this_device.name} HTTP API unavailable for Kick command."

--- a/src/wiim/controller.py
+++ b/src/wiim/controller.py
@@ -12,6 +12,7 @@ from .exceptions import WiimException
 from .consts import WiimHttpCommand, MultiroomAttribute
 from .discovery import async_discover_wiim_devices_upnp
 from .exceptions import WiimRequestException
+from .models import WiimGroupRole, WiimGroupSnapshot
 
 if TYPE_CHECKING:
     from aiohttp import ClientSession
@@ -220,17 +221,48 @@ class WiimController:
         Get the group role (leader/follower/standalone) and leader UDN for a given device.
         Returns: {"role": "leader"|"follower"|"standalone", "leader_udn": leader's UDN}
         """
+        snapshot = self.get_group_snapshot(device_udn)
+        if snapshot is None:
+            return None
+
+        return {
+            "role": snapshot.role.value,
+            "leader_udn": snapshot.leader_udn,
+        }
+
+    def get_group_snapshot(self, device_udn: str) -> WiimGroupSnapshot | None:
+        """Return a typed multiroom snapshot for the given device."""
         if device_udn in self._multiroom_groups:
-            return {"role": "leader", "leader_udn": device_udn}
+            follower_udns = tuple(self._multiroom_groups[device_udn])
+            return WiimGroupSnapshot(
+                role=WiimGroupRole.LEADER,
+                leader_udn=device_udn,
+                member_udns=(device_udn, *follower_udns),
+            )
 
         for leader_udn, follower_udns in self._multiroom_groups.items():
             if device_udn in follower_udns:
-                return {"role": "follower", "leader_udn": leader_udn}
+                return WiimGroupSnapshot(
+                    role=WiimGroupRole.FOLLOWER,
+                    leader_udn=leader_udn,
+                    member_udns=(leader_udn, *tuple(follower_udns)),
+                )
 
         if self.get_device(device_udn):
-            return {"role": "standalone", "leader_udn": device_udn}
+            return WiimGroupSnapshot(
+                role=WiimGroupRole.STANDALONE,
+                leader_udn=device_udn,
+                member_udns=(device_udn,),
+            )
 
         return None
+
+    def get_command_target_udn(self, device_udn: str) -> str | None:
+        """Return the device UDN that should receive direct commands."""
+        snapshot = self.get_group_snapshot(device_udn)
+        if snapshot is None:
+            return None
+        return snapshot.command_target_udn
 
     def get_group_members(self, device_udn: str) -> List[WiimDevice]:
         """

--- a/src/wiim/discovery.py
+++ b/src/wiim/discovery.py
@@ -3,43 +3,55 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, List
 from urllib.parse import urlparse
-from aiohttp import TCPConnector, ClientSession
 
+from aiohttp import ClientSession, TCPConnector
+from async_upnp_client.aiohttp import AiohttpSessionRequester
 from async_upnp_client.client import UpnpDevice
-
-from async_upnp_client.aiohttp import AiohttpRequester
-from async_upnp_client.exceptions import UpnpConnectionError
 from async_upnp_client.client_factory import UpnpFactory
+from async_upnp_client.exceptions import UpnpConnectionError, UpnpError
 
-from .consts import (
-    SDK_LOGGER,
-    UPNP_DEVICE_TYPE,
-    MANUFACTURER_WIIM,
-)
-from .wiim_device import WiimDevice
+from .consts import MANUFACTURER_WIIM, SDK_LOGGER, UPNP_DEVICE_TYPE, WiimHttpCommand
 from .endpoint import WiimApiEndpoint
 from .exceptions import WiimRequestException
+from .wiim_device import DEFAULT_AVAILABILITY_POLLING_INTERVAL, WiimDevice
 
 if TYPE_CHECKING:
-    from aiohttp import ClientSession
     from zeroconf import Zeroconf
 
 DISCOVERY_TIMEOUT = 10
 DEVICE_VERIFICATION_TIMEOUT = 5
 
 
+def _is_supported_wiim_device(device: UpnpDevice) -> bool:
+    """Return True if the given UPnP device matches a supported WiiM variant."""
+    return (
+        bool(device.manufacturer)
+        and MANUFACTURER_WIIM.lower() in device.manufacturer.lower()
+    ) or (
+        device.manufacturer == "Audio Pro AB"
+        and bool(device.model_name)
+        and device.model_name == "A10 Speaker"
+    )
+
+
+async def _async_create_upnp_device(
+    location: str, session: ClientSession
+) -> UpnpDevice:
+    """Create a UPnP device using the caller-managed aiohttp session."""
+    requester = AiohttpSessionRequester(
+        session, with_sleep=True, timeout=DEVICE_VERIFICATION_TIMEOUT
+    )
+    factory = UpnpFactory(requester)
+    return await factory.async_create_device(location)
+
+
 async def verify_wiim_device(
     location: str, session: ClientSession
 ) -> UpnpDevice | None:
-    """
-    Verifies if a device at a given location (URL to description.xml) is a WiiM device.
-    Returns a UpnpDevice object if verified, otherwise None.
-    """
+    """Verify if a description URL points at a supported WiiM device."""
     logger = SDK_LOGGER
-    requester = AiohttpRequester(timeout=DEVICE_VERIFICATION_TIMEOUT)
     try:
-        factory = UpnpFactory(requester)
-        device = await factory.async_create_device(location)
+        device = await _async_create_upnp_device(location, session)
         logger.debug(
             "Verifying device: %s, Manufacturer: %s, Model: %s, UDN: %s",
             device.friendly_name,
@@ -48,11 +60,7 @@ async def verify_wiim_device(
             device.udn,
         )
 
-        if (
-            device.manufacturer
-            and (MANUFACTURER_WIIM.lower() in device.manufacturer.lower()) or
-            (device.manufacturer == "Audio Pro AB" and device.model_name and device.model_name == "A10 Speaker")
-        ):
+        if _is_supported_wiim_device(device):
             logger.info(
                 "Verified WiiM device by manufacturer: %s (%s)",
                 device.friendly_name,
@@ -66,14 +74,101 @@ async def verify_wiim_device(
             location,
         )
         return None
-    except (UpnpConnectionError, asyncio.TimeoutError, WiimRequestException) as e:
-        logger.debug("Failed to verify device at %s: %s", location, e)
+    except (
+        UpnpConnectionError,
+        UpnpError,
+        asyncio.TimeoutError,
+        WiimRequestException,
+    ) as err:
+        logger.debug("Failed to verify device at %s: %s", location, err)
         return None
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as err:  # pylint: disable=broad-except
         logger.error(
-            "Unexpected error verifying device at %s: %s", location, e, exc_info=True
+            "Unexpected error verifying device at %s: %s",
+            location,
+            err,
+            exc_info=True,
         )
         return None
+
+
+async def async_create_http_api_endpoint(
+    host: str | None,
+    *,
+    protocol: str = "https",
+    port: int = 443,
+    verify_ssl: bool = False,
+) -> WiimApiEndpoint | None:
+    """Create and validate the WiiM HTTP API endpoint for a device host."""
+    if not host:
+        return None
+
+    logger = SDK_LOGGER
+    http_session = ClientSession(connector=TCPConnector(ssl=False))
+    http_api = WiimApiEndpoint(
+        protocol=protocol,
+        port=port,
+        endpoint=host,
+        session=http_session,
+        verify_ssl=verify_ssl,
+        owns_session=True,
+    )
+    try:
+        await http_api.json_request(WiimHttpCommand.DEVICE_STATUS)
+    except Exception as err:  # pylint: disable=broad-except
+        logger.warning(
+            "Could not establish default HTTP API for %s, some features might be limited: %s",
+            host,
+            err,
+        )
+        await http_api.async_close()
+        return None
+    return http_api
+
+
+async def async_create_wiim_device(
+    location: str,
+    session: ClientSession,
+    *,
+    host: str | None = None,
+    ha_host_ip: str | None = None,
+    polling_interval: int = DEFAULT_AVAILABILITY_POLLING_INTERVAL,
+    initialize: bool = True,
+) -> WiimDevice | None:
+    """Create a validated WiiM device from a UPnP location URL."""
+    logger = SDK_LOGGER
+
+    upnp_device = await verify_wiim_device(location, session)
+    if upnp_device is None:
+        return None
+
+    http_api = await async_create_http_api_endpoint(host or urlparse(location).hostname)
+
+    wiim_device = WiimDevice(
+        upnp_device,
+        session,
+        http_api_endpoint=http_api,
+        ha_host_ip=ha_host_ip,
+        polling_interval=polling_interval,
+    )
+
+    if not initialize:
+        return wiim_device
+
+    if await wiim_device.async_init_services_and_subscribe():
+        logger.info(
+            "Successfully created and initialized WiimDevice: %s (%s)",
+            wiim_device.name,
+            wiim_device.udn,
+        )
+        return wiim_device
+
+    logger.warning(
+        "Failed to initialize WiimDevice after discovery: %s",
+        upnp_device.friendly_name,
+    )
+    await wiim_device.disconnect()
+    return None
 
 
 async def async_discover_wiim_devices_upnp(
@@ -81,10 +176,7 @@ async def async_discover_wiim_devices_upnp(
     timeout: int = DISCOVERY_TIMEOUT,
     target_device_type: str = UPNP_DEVICE_TYPE,
 ) -> List[WiimDevice]:
-    """
-    Discovers WiiM devices on the network using UPnP (SSDP).
-    Creates WiimDevice instances for verified devices.
-    """
+    """Discover WiiM devices on the network using UPnP."""
     logger = SDK_LOGGER
     discovered_devices: dict[str, WiimDevice] = {}
     found_locations: set[str] = set()
@@ -106,39 +198,9 @@ async def async_discover_wiim_devices_upnp(
             )
             return
 
-        upnp_device = await verify_wiim_device(location, session)
-        if upnp_device and upnp_device.udn not in discovered_devices:
-            # Create HTTP endpoint for the WiimDevice
-            host = urlparse(location).hostname
-            http_api = None
-            if host:
-                try:
-                    sessions = ClientSession(connector=TCPConnector(ssl=False))
-                    http_api = WiimApiEndpoint(
-                        protocol="https", port=443, endpoint=host, session=sessions
-                    )
-                    await http_api.json_request("getStatusEx")
-                except Exception:  # pylint: disable=broad-except
-                    logger.warning(
-                        "Could not establish default HTTP API for %s, some features might be limited.",
-                        host,
-                    )
-                    http_api = None
-
-            wiim_dev = WiimDevice(upnp_device, session, http_api_endpoint=http_api)
-            # Initialize services and subscribe. If it fails, device won't be added.
-            if await wiim_dev.async_init_services_and_subscribe():
-                discovered_devices[upnp_device.udn] = wiim_dev
-                logger.info(
-                    "Successfully created and initialized WiimDevice: %s (%s)",
-                    wiim_dev.name,
-                    wiim_dev.udn,
-                )
-            else:
-                logger.warning(
-                    "Failed to initialize WiimDevice after discovery: %s",
-                    upnp_device.friendly_name,
-                )
+        wiim_device = await async_create_wiim_device(location, session)
+        if wiim_device and wiim_device.udn not in discovered_devices:
+            discovered_devices[wiim_device.udn] = wiim_device
 
     logger.warning(
         "async_discover_wiim_devices_upnp: SSDP discovery mechanism needs to be fully implemented "
@@ -153,13 +215,13 @@ async def async_discover_wiim_devices_zeroconf(
     zeroconf_instance: "Zeroconf",
     service_type: str = "_linkplay._tcp.local.",
 ) -> List[WiimDevice]:
-    """
-    Discovers WiiM devices using Zeroconf (mDNS) and then verifies them via UPnP.
-    This is more aligned with how Home Assistant's config flow might initiate discovery.
-    `zeroconf_instance` would be `hass.data[ZEROCONF_INSTANCE]` in HA.
-    """
+    """Discover WiiM devices using Zeroconf and then verify them via UPnP."""
+    del session
+    del zeroconf_instance
+    del service_type
+
     logger = SDK_LOGGER
-    discovered_wiim_devices: dict[str, WiimDevice] = {}  # UDN: WiimDevice
+    discovered_wiim_devices: dict[str, WiimDevice] = {}
 
     logger.warning(
         "async_discover_wiim_devices_zeroconf: Relies on external Zeroconf to provide IPs. "

--- a/src/wiim/discovery.py
+++ b/src/wiim/discovery.py
@@ -13,6 +13,7 @@ from async_upnp_client.exceptions import UpnpConnectionError, UpnpError
 from .consts import MANUFACTURER_WIIM, SDK_LOGGER, UPNP_DEVICE_TYPE, WiimHttpCommand
 from .endpoint import WiimApiEndpoint
 from .exceptions import WiimRequestException
+from .models import WiimProbeResult
 from .wiim_device import DEFAULT_AVAILABILITY_POLLING_INTERVAL, WiimDevice
 
 if TYPE_CHECKING:
@@ -124,6 +125,30 @@ async def async_create_http_api_endpoint(
         await http_api.async_close()
         return None
     return http_api
+
+
+async def async_probe_wiim_device(
+    location: str,
+    session: ClientSession,
+    *,
+    host: str | None = None,
+) -> WiimProbeResult | None:
+    """Probe a WiiM device and return normalized discovery information."""
+    upnp_device = await verify_wiim_device(location, session)
+    if upnp_device is None:
+        return None
+
+    resolved_host = host or urlparse(location).hostname
+    if resolved_host is None:
+        return None
+
+    return WiimProbeResult(
+        udn=upnp_device.udn,
+        name=upnp_device.friendly_name,
+        model=upnp_device.model_name or "WiiM Device",
+        host=resolved_host,
+        location=location or upnp_device.device_url,
+    )
 
 
 async def async_create_wiim_device(

--- a/src/wiim/discovery.py
+++ b/src/wiim/discovery.py
@@ -12,7 +12,7 @@ from async_upnp_client.exceptions import UpnpConnectionError, UpnpError
 
 from .consts import MANUFACTURER_WIIM, SDK_LOGGER, UPNP_DEVICE_TYPE, WiimHttpCommand
 from .endpoint import WiimApiEndpoint
-from .exceptions import WiimRequestException
+from .exceptions import WiimDeviceException, WiimRequestException
 from .models import WiimProbeResult
 from .wiim_device import DEFAULT_AVAILABILITY_POLLING_INTERVAL, WiimDevice
 
@@ -156,16 +156,16 @@ async def async_create_wiim_device(
     session: ClientSession,
     *,
     host: str | None = None,
-    ha_host_ip: str | None = None,
+    local_host: str | None = None,
     polling_interval: int = DEFAULT_AVAILABILITY_POLLING_INTERVAL,
     initialize: bool = True,
-) -> WiimDevice | None:
+) -> WiimDevice:
     """Create a validated WiiM device from a UPnP location URL."""
     logger = SDK_LOGGER
 
     upnp_device = await verify_wiim_device(location, session)
     if upnp_device is None:
-        return None
+        raise WiimRequestException(f"Failed to verify WiiM device at {location}")
 
     http_api = await async_create_http_api_endpoint(host or urlparse(location).hostname)
 
@@ -173,7 +173,7 @@ async def async_create_wiim_device(
         upnp_device,
         session,
         http_api_endpoint=http_api,
-        ha_host_ip=ha_host_ip,
+        local_host=local_host,
         polling_interval=polling_interval,
     )
 
@@ -193,7 +193,9 @@ async def async_create_wiim_device(
         upnp_device.friendly_name,
     )
     await wiim_device.disconnect()
-    return None
+    raise WiimDeviceException(
+        f"Failed to initialize WiiM device from {upnp_device.friendly_name}"
+    )
 
 
 async def async_discover_wiim_devices_upnp(
@@ -223,8 +225,13 @@ async def async_discover_wiim_devices_upnp(
             )
             return
 
-        wiim_device = await async_create_wiim_device(location, session)
-        if wiim_device and wiim_device.udn not in discovered_devices:
+        try:
+            wiim_device = await async_create_wiim_device(location, session)
+        except (WiimDeviceException, WiimRequestException) as err:
+            logger.debug("Skipping device at %s during discovery: %s", location, err)
+            return
+
+        if wiim_device.udn not in discovered_devices:
             discovered_devices[wiim_device.udn] = wiim_device
 
     logger.warning(

--- a/src/wiim/endpoint.py
+++ b/src/wiim/endpoint.py
@@ -39,7 +39,14 @@ class WiimApiEndpoint(WiimBaseEndpoint):
     """Represents a WiiM HTTP API endpoint."""
 
     def __init__(
-        self, *, protocol: str, port: int, endpoint: str, session: ClientSession
+        self,
+        *,
+        protocol: str,
+        port: int,
+        endpoint: str,
+        session: ClientSession,
+        verify_ssl: bool = True,
+        owns_session: bool = False,
     ):
         assert protocol in [
             "http",
@@ -52,6 +59,10 @@ class WiimApiEndpoint(WiimBaseEndpoint):
         port_suffix = f":{port}" if include_port else ""
         self._base_url: str = f"{protocol}://{endpoint}{port_suffix}"
         self._session: ClientSession = session
+        self._owns_session = owns_session
+        self._request_kwargs: dict[str, Any] = {}
+        if protocol == "https" and not verify_ssl:
+            self._request_kwargs["ssl"] = False
         self.logger.debug("WiimApiEndpoint initialized for %s", self._base_url)
 
     def to_dict(self) -> dict[str, str]:
@@ -67,7 +78,9 @@ class WiimApiEndpoint(WiimBaseEndpoint):
         self.logger.debug(f"Requesting (expect OK): {url}")
         try:
             async with self._session.get(
-                url, timeout=ClientTimeout(total=API_TIMEOUT)
+                url,
+                timeout=ClientTimeout(total=API_TIMEOUT),
+                **self._request_kwargs,
             ) as response:
                 response_text = await response.text()
                 self.logger.debug(
@@ -97,7 +110,9 @@ class WiimApiEndpoint(WiimBaseEndpoint):
         self.logger.debug(f"Requesting (expect JSON): {url}")
         try:
             async with self._session.get(
-                url, timeout=ClientTimeout(total=API_TIMEOUT)
+                url,
+                timeout=ClientTimeout(total=API_TIMEOUT),
+                **self._request_kwargs,
             ) as response:
                 response_text = await response.text()
                 self.logger.debug(
@@ -159,3 +174,8 @@ class WiimApiEndpoint(WiimBaseEndpoint):
 
     def __str__(self) -> str:
         return self._base_url
+
+    async def async_close(self) -> None:
+        """Close the underlying aiohttp session if this endpoint owns it."""
+        if self._owns_session and not self._session.closed:
+            await self._session.close()

--- a/src/wiim/models.py
+++ b/src/wiim/models.py
@@ -94,3 +94,14 @@ class WiimGroupSnapshot:
     def command_target_udn(self) -> str:
         """Return the device UDN that should receive direct commands."""
         return self.leader_udn
+
+
+@dataclass(frozen=True, slots=True)
+class WiimProbeResult:
+    """Normalized probe result for discovery/config flows."""
+
+    udn: str
+    name: str
+    model: str
+    host: str
+    location: str

--- a/src/wiim/models.py
+++ b/src/wiim/models.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+@dataclass(frozen=True, slots=True)
+class WiimMediaMetadata:
+    """Normalized media metadata exposed by the SDK."""
+
+    title: str | None = None
+    artist: str | None = None
+    album: str | None = None
+    image_url: str | None = None
+    uri: str | None = None
+    duration: int | None = None
+    position: int | None = None
+
+
+class WiimRepeatMode(StrEnum):
+    """Normalized repeat mode independent of Home Assistant."""
+
+    OFF = "off"
+    ONE = "one"
+    ALL = "all"
+
+
+@dataclass(frozen=True, slots=True)
+class WiimLoopState:
+    """Normalized loop/shuffle state exposed by the SDK."""
+
+    repeat: WiimRepeatMode
+    shuffle: bool

--- a/src/wiim/models.py
+++ b/src/wiim/models.py
@@ -72,3 +72,25 @@ class WiimQueueSnapshot:
     play_medium: str = ""
     track_source: str = ""
     is_active: bool = False
+
+
+class WiimGroupRole(StrEnum):
+    """Normalized multiroom role for a device."""
+
+    LEADER = "leader"
+    FOLLOWER = "follower"
+    STANDALONE = "standalone"
+
+
+@dataclass(frozen=True, slots=True)
+class WiimGroupSnapshot:
+    """Normalized group state for a device."""
+
+    role: WiimGroupRole
+    leader_udn: str
+    member_udns: tuple[str, ...]
+
+    @property
+    def command_target_udn(self) -> str:
+        """Return the device UDN that should receive direct commands."""
+        return self.leader_udn

--- a/src/wiim/models.py
+++ b/src/wiim/models.py
@@ -31,3 +31,44 @@ class WiimLoopState:
 
     repeat: WiimRepeatMode
     shuffle: bool
+
+
+@dataclass(frozen=True, slots=True)
+class WiimTransportCapabilities:
+    """Normalized transport capabilities derived from MEDIA_INFO."""
+
+    can_next: bool = True
+    can_previous: bool = True
+    can_repeat: bool = False
+    can_shuffle: bool = False
+    play_medium: str = ""
+    track_source: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class WiimPreset:
+    """A normalized preset entry."""
+
+    preset_id: int
+    title: str
+    image_url: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WiimQueueItem:
+    """A normalized queue item."""
+
+    queue_index: int
+    title: str
+    image_url: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WiimQueueSnapshot:
+    """Normalized queue browse state."""
+
+    items: tuple[WiimQueueItem, ...]
+    source_name: str | None = None
+    play_medium: str = ""
+    track_source: str = ""
+    is_active: bool = False

--- a/src/wiim/wiim_device.py
+++ b/src/wiim/wiim_device.py
@@ -89,7 +89,7 @@ class WiimDevice:
         upnp_device: UpnpDevice,
         session: ClientSession,
         http_api_endpoint: WiimApiEndpoint | None = None,
-        ha_host_ip: str | None = None,
+        local_host: str | None = None,
         polling_interval: int = DEFAULT_AVAILABILITY_POLLING_INTERVAL,
     ):
         """Initialize the WiiM device."""
@@ -143,7 +143,7 @@ class WiimDevice:
         if hasattr(self.upnp_device, "requester") and self.upnp_device.requester:
             self.requester_for_eventing = self.upnp_device.requester  # type: ignore
 
-        self.ha_host_ip = ha_host_ip
+        self.local_host = local_host
         self.volume: int = 0
         self.is_muted: bool = False
         self.playing_status: PlayingStatus = PlayingStatus.STOPPED
@@ -194,7 +194,7 @@ class WiimDevice:
         if self.requester_for_eventing:
             try:
                 loop = asyncio.get_event_loop()
-                local_ip = self.ha_host_ip
+                local_ip = self.local_host
                 device_ip = self.ip_address
                 if device_ip:
                     last_octet = int(device_ip.split(".")[-1])

--- a/src/wiim/wiim_device.py
+++ b/src/wiim/wiim_device.py
@@ -1767,6 +1767,19 @@ class WiimDevice:
                     exc_info=True,
                 )
 
+        if self._http_api:
+            try:
+                await self._http_api.async_close()
+            except Exception as err:
+                self.logger.warning(
+                    "Device %s: Error closing HTTP API session: %s",
+                    self.name,
+                    err,
+                    exc_info=True,
+                )
+            finally:
+                self._http_api = None
+
         self._event_handler_started = False
         self._available = False
 

--- a/src/wiim/wiim_device.py
+++ b/src/wiim/wiim_device.py
@@ -20,6 +20,8 @@ from .consts import (
     CMD_TO_MODE_MAP,
     SDK_LOGGER,
     MANUFACTURER_WIIM,
+    SUPPORTED_INPUT_MODES_BY_MODEL,
+    SUPPORTED_OUTPUT_MODES_BY_MODEL,
     UPNP_AV_TRANSPORT_SERVICE_ID,
     UPNP_RENDERING_CONTROL_SERVICE_ID,
     UPNP_WIIM_PLAY_QUEUE_SERVICE_ID,
@@ -39,11 +41,13 @@ from .consts import (
     WiimHttpCommand,
     UPNP_TIMEOUT_TIME,
     AUDIO_AUX_MODE_IDS,
+    wiimDeviceType,
 )
 from .endpoint import WiimApiEndpoint
 from .exceptions import WiimDeviceException, WiimRequestException
 from .handler import parse_last_change_event
 from .manufacturers import get_info_from_project
+from .models import WiimLoopState, WiimMediaMetadata, WiimRepeatMode
 
 if TYPE_CHECKING:
     from aiohttp import ClientSession
@@ -155,6 +159,20 @@ class WiimDevice:
 
         self._polling_interval = polling_interval
         self._polling_task: asyncio.Task | None = None
+
+    def _supported_model_name(self) -> str | None:
+        """Return the best model name available for capability lookups."""
+        model_name = self.model_name
+        if (
+            model_name in SUPPORTED_INPUT_MODES_BY_MODEL
+            or model_name in SUPPORTED_OUTPUT_MODES_BY_MODEL
+        ):
+            return model_name
+
+        if self._udn.startswith("uuid:") and len(self._udn) >= 13:
+            return wiimDeviceType.get(self._udn[5:13], model_name)
+
+        return model_name
 
     async def async_init_services_and_subscribe(self) -> bool:
         """
@@ -910,6 +928,9 @@ class WiimDevice:
                     "albumArtURI": self.make_absolute_url(  # noqa: SLF001
                         meta.get("albumArtURI")
                     ),
+                    "album_art_uri": self.make_absolute_url(  # noqa: SLF001
+                        meta.get("albumArtURI")
+                    ),
                 }
 
             except Exception as e:
@@ -1473,6 +1494,40 @@ class WiimDevice:
         )
 
     @property
+    def supported_input_modes(self) -> tuple[str, ...]:
+        """Return the supported input mode display names for the device."""
+        model_name = self._supported_model_name()
+        if not model_name:
+            return ()
+
+        modes_flag = SUPPORTED_INPUT_MODES_BY_MODEL.get(model_name)
+        if modes_flag is None:
+            return ()
+
+        return tuple(
+            mode.display_name  # type: ignore[attr-defined]
+            for mode in InputMode
+            if modes_flag & mode.value
+        )
+
+    @property
+    def supported_output_modes(self) -> tuple[str, ...]:
+        """Return the supported output mode display names for the device."""
+        model_name = self._supported_model_name()
+        if not model_name:
+            return ()
+
+        modes_flag = SUPPORTED_OUTPUT_MODES_BY_MODEL.get(model_name)
+        if modes_flag is None:
+            return ()
+
+        return tuple(
+            mode.display_name  # type: ignore[attr-defined]
+            for mode in AudioOutputHwMode
+            if modes_flag & mode.value
+        )
+
+    @property
     def firmware_version(self) -> str | None:
         """Return the firmware version from HTTP API."""
         if hasattr(self, "_device_info_properties") and self._device_info_properties:
@@ -1519,7 +1574,83 @@ class WiimDevice:
     @property
     def album_art_uri(self) -> str | None:
         """Return the current track's album art URI."""
-        return self.current_track_info.get("album_art_uri")
+        if media := self.current_media:
+            return media.image_url
+        return None
+
+    @property
+    def current_media(self) -> WiimMediaMetadata | None:
+        """Return normalized current media metadata."""
+        if not self.current_track_info:
+            return None
+
+        return WiimMediaMetadata(
+            title=self.current_track_info.get("title"),
+            artist=self.current_track_info.get("artist"),
+            album=self.current_track_info.get("album"),
+            image_url=self.current_track_info.get("albumArtURI")
+            or self.current_track_info.get("album_art_uri"),
+            uri=self.current_track_info.get("uri"),
+            duration=self.current_track_duration or self.current_track_info.get(
+                "duration"
+            ),
+            position=self.current_position,
+        )
+
+    @property
+    def loop_state(self) -> WiimLoopState:
+        """Return normalized repeat/shuffle settings for the current loop mode."""
+        mapping = {
+            LoopMode.SHUFFLE_DISABLE_REPEAT_ALL: WiimLoopState(
+                repeat=WiimRepeatMode.ALL,
+                shuffle=False,
+            ),
+            LoopMode.SHUFFLE_DISABLE_REPEAT_ONE: WiimLoopState(
+                repeat=WiimRepeatMode.ONE,
+                shuffle=False,
+            ),
+            LoopMode.SHUFFLE_ENABLE_REPEAT_ALL: WiimLoopState(
+                repeat=WiimRepeatMode.ALL,
+                shuffle=True,
+            ),
+            LoopMode.SHUFFLE_ENABLE_REPEAT_NONE: WiimLoopState(
+                repeat=WiimRepeatMode.OFF,
+                shuffle=True,
+            ),
+            LoopMode.SHUFFLE_DISABLE_REPEAT_NONE: WiimLoopState(
+                repeat=WiimRepeatMode.OFF,
+                shuffle=False,
+            ),
+            LoopMode.SHUFFLE_ENABLE_REPEAT_ONE: WiimLoopState(
+                repeat=WiimRepeatMode.ONE,
+                shuffle=True,
+            ),
+        }
+        return mapping.get(
+            self.loop_mode,
+            WiimLoopState(repeat=WiimRepeatMode.OFF, shuffle=False),
+        )
+
+    @staticmethod
+    def build_loop_mode(repeat: WiimRepeatMode, shuffle: bool) -> LoopMode:
+        """Return the SDK loop mode for the given repeat and shuffle settings."""
+        if repeat == WiimRepeatMode.ALL:
+            return (
+                LoopMode.SHUFFLE_ENABLE_REPEAT_ALL
+                if shuffle
+                else LoopMode.SHUFFLE_DISABLE_REPEAT_ALL
+            )
+        if repeat == WiimRepeatMode.ONE:
+            return (
+                LoopMode.SHUFFLE_ENABLE_REPEAT_ONE
+                if shuffle
+                else LoopMode.SHUFFLE_DISABLE_REPEAT_ONE
+            )
+        return (
+            LoopMode.SHUFFLE_ENABLE_REPEAT_NONE
+            if shuffle
+            else LoopMode.SHUFFLE_DISABLE_REPEAT_NONE
+        )
 
     @property
     def manufacturer(self) -> str | None:

--- a/src/wiim/wiim_device.py
+++ b/src/wiim/wiim_device.py
@@ -20,8 +20,10 @@ from .consts import (
     CMD_TO_MODE_MAP,
     SDK_LOGGER,
     MANUFACTURER_WIIM,
+    PLAY_MEDIUMS_CTRL,
     SUPPORTED_INPUT_MODES_BY_MODEL,
     SUPPORTED_OUTPUT_MODES_BY_MODEL,
+    TRACK_SOURCES_CTRL,
     UPNP_AV_TRANSPORT_SERVICE_ID,
     UPNP_RENDERING_CONTROL_SERVICE_ID,
     UPNP_WIIM_PLAY_QUEUE_SERVICE_ID,
@@ -41,13 +43,22 @@ from .consts import (
     WiimHttpCommand,
     UPNP_TIMEOUT_TIME,
     AUDIO_AUX_MODE_IDS,
+    VALID_PLAY_MEDIUMS,
     wiimDeviceType,
 )
 from .endpoint import WiimApiEndpoint
 from .exceptions import WiimDeviceException, WiimRequestException
 from .handler import parse_last_change_event
 from .manufacturers import get_info_from_project
-from .models import WiimLoopState, WiimMediaMetadata, WiimRepeatMode
+from .models import (
+    WiimLoopState,
+    WiimMediaMetadata,
+    WiimPreset,
+    WiimQueueItem,
+    WiimQueueSnapshot,
+    WiimRepeatMode,
+    WiimTransportCapabilities,
+)
 
 if TYPE_CHECKING:
     from aiohttp import ClientSession
@@ -1316,6 +1327,42 @@ class WiimDevice:
         )
         self.loop_mode = loop
 
+    async def async_get_transport_capabilities(self) -> WiimTransportCapabilities:
+        """Return normalized transport capabilities for the current media context."""
+        if not self.supports_http_api:
+            return WiimTransportCapabilities()
+
+        media_info = await self.async_set_AVT_cmd(WiimHttpCommand.MEDIA_INFO)
+        if not isinstance(media_info, dict):
+            return WiimTransportCapabilities()
+
+        play_medium = media_info.get("PlayMedium")
+        if not isinstance(play_medium, str):
+            play_medium = ""
+
+        track_source = media_info.get("TrackSource")
+        if not isinstance(track_source, str):
+            track_source = ""
+
+        can_next = True
+        can_previous = True
+        if play_medium in PLAY_MEDIUMS_CTRL:
+            can_next = False
+            can_previous = False
+        elif track_source in TRACK_SOURCES_CTRL:
+            can_previous = False
+
+        loop_supported = play_medium in VALID_PLAY_MEDIUMS and track_source != ""
+
+        return WiimTransportCapabilities(
+            can_next=can_next,
+            can_previous=can_previous,
+            can_repeat=loop_supported,
+            can_shuffle=loop_supported,
+            play_medium=play_medium,
+            track_source=track_source,
+        )
+
     async def async_play_queue_with_index(self, index: int) -> None:
         """Set loop/repeat mode using UPnP."""
         await self._invoke_upnp_action(
@@ -1362,6 +1409,26 @@ class WiimDevice:
         except WiimDeviceException:
             return []
 
+    async def async_get_presets(self) -> tuple[WiimPreset, ...]:
+        """Return normalized presets for browsing."""
+        presets = await self.async_get_favorites()
+        results: list[WiimPreset] = []
+        for item in presets:
+            preset_id = item.get("uri")
+            if not preset_id or not str(preset_id).isdigit():
+                continue
+
+            preset_name = item.get("name", "")
+            title = preset_name.split("_#~", 1)[0] if "_#~" in preset_name else preset_name
+            results.append(
+                WiimPreset(
+                    preset_id=int(preset_id),
+                    title=title,
+                    image_url=item.get("image_url"),
+                )
+            )
+        return tuple(results)
+
     def _parse_preset_data(self, xml_str: str) -> list:
         """Parse queue data from PlayQueue service (needs actual format)."""
         try:
@@ -1405,6 +1472,60 @@ class WiimDevice:
             return self._parse_queue_data(result.get("QueueContext", ""))
         except WiimDeviceException:
             return []
+
+    async def async_get_queue_snapshot(self) -> WiimQueueSnapshot:
+        """Return normalized queue information for browsing."""
+        queue_items = await self.async_get_queue_items()
+        source_name = next(
+            (
+                item["SourceName"]
+                for item in queue_items
+                if isinstance(item, dict) and "SourceName" in item
+            ),
+            None,
+        )
+
+        media_info = await self.async_set_AVT_cmd(WiimHttpCommand.MEDIA_INFO)
+        if not isinstance(media_info, dict):
+            return WiimQueueSnapshot(items=(), source_name=source_name)
+
+        play_medium = media_info.get("PlayMedium")
+        if not isinstance(play_medium, str):
+            play_medium = ""
+
+        track_source = media_info.get("TrackSource")
+        if not isinstance(track_source, str):
+            track_source = ""
+
+        browseable = (
+            play_medium in VALID_PLAY_MEDIUMS
+            and track_source != ""
+            and (
+                source_name is None
+                or source_name == "MyFavouriteQueue"
+                or track_source in source_name
+            )
+        )
+
+        normalized_items = tuple(
+            WiimQueueItem(
+                queue_index=int(item["uri"]),
+                title=item["name"],
+                image_url=item.get("image_url"),
+            )
+            for item in queue_items
+            if isinstance(item, dict)
+            and str(item.get("uri", "")).isdigit()
+            and "name" in item
+        )
+
+        return WiimQueueSnapshot(
+            items=normalized_items,
+            source_name=source_name,
+            play_medium=play_medium,
+            track_source=track_source,
+            is_active=browseable,
+        )
 
     def _parse_queue_data(self, xml_str: str) -> list:
         """Parse queue data from PlayQueue service (needs actual format)."""

--- a/tests/wiim/test_controller.py
+++ b/tests/wiim/test_controller.py
@@ -2,6 +2,7 @@
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 from wiim.controller import WiimController
+from wiim.models import WiimGroupRole
 from wiim.wiim_device import WiimDevice
 from wiim.consts import WiimHttpCommand, MultiroomAttribute
 
@@ -94,6 +95,31 @@ class TestWiimController:
             "leader_udn": "standalone_udn",
         }
         assert controller.get_device_group_info("unknown_udn") is None
+
+    def test_get_group_snapshot(self, mock_session):
+        """Test typed group snapshots."""
+        controller = WiimController(mock_session)
+        controller._multiroom_groups = {"leader_udn": ["follower_udn"]}
+        controller._devices = {
+            "leader_udn": MagicMock(),
+            "follower_udn": MagicMock(),
+            "standalone_udn": MagicMock(),
+        }
+
+        leader_snapshot = controller.get_group_snapshot("leader_udn")
+        follower_snapshot = controller.get_group_snapshot("follower_udn")
+        standalone_snapshot = controller.get_group_snapshot("standalone_udn")
+
+        assert leader_snapshot is not None
+        assert leader_snapshot.role == WiimGroupRole.LEADER
+        assert leader_snapshot.member_udns == ("leader_udn", "follower_udn")
+        assert follower_snapshot is not None
+        assert follower_snapshot.role == WiimGroupRole.FOLLOWER
+        assert follower_snapshot.command_target_udn == "leader_udn"
+        assert standalone_snapshot is not None
+        assert standalone_snapshot.role == WiimGroupRole.STANDALONE
+        assert standalone_snapshot.member_udns == ("standalone_udn",)
+        assert controller.get_command_target_udn("follower_udn") == "leader_udn"
 
     @pytest.mark.asyncio
     async def test_async_join_group(self, mock_session, mock_wiim_device):

--- a/tests/wiim/test_controller.py
+++ b/tests/wiim/test_controller.py
@@ -25,6 +25,13 @@ class TestWiimController:
         assert len(controller.devices) == 0
         mock_wiim_device.disconnect.assert_called_once()
 
+    def test_get_device_raises_for_unknown_udn(self, mock_session):
+        """Test managed device lookups raise for unknown UDNs."""
+        controller = WiimController(mock_session)
+
+        with pytest.raises(ValueError, match="unknown_udn"):
+            controller.get_device("unknown_udn")
+
     def test_restore_full_udn(self, mock_session):
         """Test the helper function that reconstructs a full UDN from a short UUID."""
         controller = WiimController(mock_session)
@@ -94,7 +101,8 @@ class TestWiimController:
             "role": "standalone",
             "leader_udn": "standalone_udn",
         }
-        assert controller.get_device_group_info("unknown_udn") is None
+        with pytest.raises(ValueError, match="unknown_udn"):
+            controller.get_device_group_info("unknown_udn")
 
     def test_get_group_snapshot(self, mock_session):
         """Test typed group snapshots."""
@@ -120,6 +128,9 @@ class TestWiimController:
         assert standalone_snapshot.role == WiimGroupRole.STANDALONE
         assert standalone_snapshot.member_udns == ("standalone_udn",)
         assert controller.get_command_target_udn("follower_udn") == "leader_udn"
+
+        with pytest.raises(ValueError, match="unknown_udn"):
+            controller.get_group_snapshot("unknown_udn")
 
     @pytest.mark.asyncio
     async def test_async_join_group(self, mock_session, mock_wiim_device):

--- a/tests/wiim/test_discovery.py
+++ b/tests/wiim/test_discovery.py
@@ -3,7 +3,11 @@ from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
 from async_upnp_client.exceptions import UpnpConnectionError
-from wiim.discovery import async_create_wiim_device, verify_wiim_device
+from wiim.discovery import (
+    async_create_wiim_device,
+    async_probe_wiim_device,
+    verify_wiim_device,
+)
 
 
 @pytest.mark.asyncio
@@ -165,3 +169,31 @@ class TestDiscovery:
 
         assert device is None
         mock_wiim_device.disconnect.assert_awaited_once()
+
+    @patch("wiim.discovery.UpnpFactory")
+    async def test_async_probe_wiim_device(
+        self,
+        mock_factory,
+        mock_session,
+    ):
+        """Test probing returns normalized discovery data."""
+        mock_upnp_device = MagicMock()
+        mock_upnp_device.manufacturer = "Linkplay Technology Inc."
+        mock_upnp_device.friendly_name = "WiiM Pro"
+        mock_upnp_device.udn = "uuid:some-udn"
+        mock_upnp_device.model_name = "WiiM Pro"
+        mock_factory.return_value.async_create_device = AsyncMock(
+            return_value=mock_upnp_device
+        )
+
+        result = await async_probe_wiim_device(
+            "http://192.168.1.10:49152/description.xml",
+            mock_session,
+        )
+
+        assert result is not None
+        assert result.udn == "uuid:some-udn"
+        assert result.name == "WiiM Pro"
+        assert result.model == "WiiM Pro"
+        assert result.host == "192.168.1.10"
+        assert result.location == "http://192.168.1.10:49152/description.xml"

--- a/tests/wiim/test_discovery.py
+++ b/tests/wiim/test_discovery.py
@@ -1,8 +1,9 @@
 # test_discovery.py
-import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
+
+import pytest
 from async_upnp_client.exceptions import UpnpConnectionError
-from wiim.discovery import verify_wiim_device
+from wiim.discovery import async_create_wiim_device, verify_wiim_device
 
 
 @pytest.mark.asyncio
@@ -71,3 +72,96 @@ class TestDiscovery:
         device = await verify_wiim_device("http://location", mock_session)
 
         assert device is None
+
+    @patch("wiim.discovery.ClientSession")
+    @patch("wiim.discovery.WiimDevice")
+    @patch("wiim.discovery.WiimApiEndpoint")
+    @patch("wiim.discovery.UpnpFactory")
+    async def test_async_create_wiim_device_success(
+        self,
+        mock_factory,
+        mock_http_api_cls,
+        mock_wiim_device_cls,
+        mock_client_session_cls,
+        mock_session,
+    ):
+        """Test creation of a fully initialized WiiM device from a location."""
+        mock_upnp_device = MagicMock()
+        mock_upnp_device.manufacturer = "Linkplay Technology Inc."
+        mock_upnp_device.friendly_name = "WiiM Pro"
+        mock_upnp_device.udn = "uuid:some-udn"
+        mock_factory.return_value.async_create_device = AsyncMock(
+            return_value=mock_upnp_device
+        )
+
+        mock_http_api = AsyncMock()
+        mock_http_api.json_request = AsyncMock(return_value={"status": "ok"})
+        mock_http_api_cls.return_value = mock_http_api
+        http_session = MagicMock()
+        mock_client_session_cls.return_value = http_session
+
+        mock_wiim_device = MagicMock()
+        mock_wiim_device.name = "WiiM Pro"
+        mock_wiim_device.udn = "uuid:some-udn"
+        mock_wiim_device.async_init_services_and_subscribe = AsyncMock(
+            return_value=True
+        )
+        mock_wiim_device_cls.return_value = mock_wiim_device
+
+        device = await async_create_wiim_device(
+            "http://192.168.1.10:49152/description.xml",
+            mock_session,
+            ha_host_ip="192.168.1.2",
+        )
+
+        assert device is mock_wiim_device
+        mock_http_api_cls.assert_called_once_with(
+            protocol="https",
+            port=443,
+            endpoint="192.168.1.10",
+            session=http_session,
+            verify_ssl=False,
+            owns_session=True,
+        )
+        mock_wiim_device_cls.assert_called_once_with(
+            mock_upnp_device,
+            mock_session,
+            http_api_endpoint=mock_http_api,
+            ha_host_ip="192.168.1.2",
+            polling_interval=60,
+        )
+
+    @patch("wiim.discovery.ClientSession")
+    @patch("wiim.discovery.WiimDevice")
+    @patch("wiim.discovery.UpnpFactory")
+    async def test_async_create_wiim_device_disconnects_failed_init(
+        self,
+        mock_factory,
+        mock_wiim_device_cls,
+        mock_client_session_cls,
+        mock_session,
+    ):
+        """Test failed initialization disconnects the partially created device."""
+        mock_upnp_device = MagicMock()
+        mock_upnp_device.manufacturer = "Linkplay Technology Inc."
+        mock_upnp_device.friendly_name = "WiiM Pro"
+        mock_upnp_device.udn = "uuid:some-udn"
+        mock_factory.return_value.async_create_device = AsyncMock(
+            return_value=mock_upnp_device
+        )
+
+        mock_wiim_device = MagicMock()
+        mock_wiim_device.async_init_services_and_subscribe = AsyncMock(
+            return_value=False
+        )
+        mock_wiim_device.disconnect = AsyncMock()
+        mock_wiim_device_cls.return_value = mock_wiim_device
+        mock_client_session_cls.return_value = MagicMock()
+
+        device = await async_create_wiim_device(
+            "http://192.168.1.10:49152/description.xml",
+            mock_session,
+        )
+
+        assert device is None
+        mock_wiim_device.disconnect.assert_awaited_once()

--- a/tests/wiim/test_discovery.py
+++ b/tests/wiim/test_discovery.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
 from async_upnp_client.exceptions import UpnpConnectionError
+from wiim.exceptions import WiimDeviceException, WiimRequestException
 from wiim.discovery import (
     async_create_wiim_device,
     async_probe_wiim_device,
@@ -115,7 +116,7 @@ class TestDiscovery:
         device = await async_create_wiim_device(
             "http://192.168.1.10:49152/description.xml",
             mock_session,
-            ha_host_ip="192.168.1.2",
+            local_host="192.168.1.2",
         )
 
         assert device is mock_wiim_device
@@ -131,7 +132,7 @@ class TestDiscovery:
             mock_upnp_device,
             mock_session,
             http_api_endpoint=mock_http_api,
-            ha_host_ip="192.168.1.2",
+            local_host="192.168.1.2",
             polling_interval=60,
         )
 
@@ -162,13 +163,33 @@ class TestDiscovery:
         mock_wiim_device_cls.return_value = mock_wiim_device
         mock_client_session_cls.return_value = MagicMock()
 
-        device = await async_create_wiim_device(
-            "http://192.168.1.10:49152/description.xml",
-            mock_session,
+        with pytest.raises(WiimDeviceException, match="Failed to initialize WiiM device"):
+            await async_create_wiim_device(
+                "http://192.168.1.10:49152/description.xml",
+                mock_session,
+            )
+
+        mock_wiim_device.disconnect.assert_awaited_once()
+
+    @patch("wiim.discovery.UpnpFactory")
+    async def test_async_create_wiim_device_raises_on_verify_failure(
+        self,
+        mock_factory,
+        mock_session,
+    ):
+        """Test failed verification raises instead of returning None."""
+        mock_factory.return_value.async_create_device = AsyncMock(
+            side_effect=UpnpConnectionError("Connection failed")
         )
 
-        assert device is None
-        mock_wiim_device.disconnect.assert_awaited_once()
+        with pytest.raises(
+            WiimRequestException,
+            match="Failed to verify WiiM device",
+        ):
+            await async_create_wiim_device(
+                "http://192.168.1.10:49152/description.xml",
+                mock_session,
+            )
 
     @patch("wiim.discovery.UpnpFactory")
     async def test_async_probe_wiim_device(

--- a/tests/wiim/test_endpoint.py
+++ b/tests/wiim/test_endpoint.py
@@ -59,6 +59,42 @@ class TestWiimApiEndpoint:
             await endpoint.request("getStatusEx")
 
     @pytest.mark.asyncio
+    async def test_request_with_ssl_verification_disabled(self, mock_session):
+        """Test disabling SSL verification uses the shared session with ssl=False."""
+        endpoint = WiimApiEndpoint(
+            protocol="https",
+            port=443,
+            endpoint="192.168.1.1",
+            session=mock_session,
+            verify_ssl=False,
+        )
+
+        await endpoint.request("getStatusEx")
+
+        mock_session.get.assert_called_with(
+            "https://192.168.1.1/httpapi.asp?command=getStatusEx",
+            timeout=ANY,
+            ssl=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_close_owned_session(self, mock_session):
+        """Test owned sessions are closed by the endpoint."""
+        mock_session.closed = False
+        mock_session.close = AsyncMock()
+        endpoint = WiimApiEndpoint(
+            protocol="https",
+            port=443,
+            endpoint="192.168.1.1",
+            session=mock_session,
+            owns_session=True,
+        )
+
+        await endpoint.async_close()
+
+        mock_session.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_json_request_ok(self, mock_session):
         """Test a successful request that returns JSON."""
         mock_session.get.return_value.__aenter__.return_value.json = AsyncMock(

--- a/tests/wiim/test_wiim_device.py
+++ b/tests/wiim/test_wiim_device.py
@@ -7,7 +7,6 @@ from wiim.consts import (
     DeviceAttribute,
     PlayerAttribute,
     PlayingStatus,
-    MuteMode,
     WiimHttpCommand,
     InputMode,
 )

--- a/tests/wiim/test_wiim_device.py
+++ b/tests/wiim/test_wiim_device.py
@@ -180,3 +180,69 @@ class TestWiimDevice:
             WiimDevice.build_loop_mode(WiimRepeatMode.ALL, shuffle=False)
             == LoopMode.SHUFFLE_DISABLE_REPEAT_ALL
         )
+
+    @pytest.mark.asyncio
+    async def test_async_get_transport_capabilities(
+        self, mock_upnp_device, mock_session
+    ):
+        """Test MEDIA_INFO is normalized into SDK transport capabilities."""
+        device = WiimDevice(mock_upnp_device, mock_session)
+        device._http_api = AsyncMock(spec=WiimApiEndpoint)
+        device.async_set_AVT_cmd = AsyncMock(
+            return_value={
+                "PlayMedium": "SONGLIST-NETWORK",
+                "TrackSource": "Pandora2",
+            }
+        )
+
+        capabilities = await device.async_get_transport_capabilities()
+
+        assert capabilities.can_next is True
+        assert capabilities.can_previous is False
+        assert capabilities.can_repeat is True
+        assert capabilities.can_shuffle is True
+        assert capabilities.track_source == "Pandora2"
+
+    @pytest.mark.asyncio
+    async def test_async_get_presets(self, mock_upnp_device, mock_session):
+        """Test presets are normalized for browse consumers."""
+        device = WiimDevice(mock_upnp_device, mock_session)
+        device.async_get_favorites = AsyncMock(
+            return_value=[
+                {"uri": "1", "name": "Preset Name_#~meta", "image_url": "art.jpg"},
+                {"uri": "x", "name": "Ignored"},
+            ]
+        )
+
+        presets = await device.async_get_presets()
+
+        assert len(presets) == 1
+        assert presets[0].preset_id == 1
+        assert presets[0].title == "Preset Name"
+        assert presets[0].image_url == "art.jpg"
+
+    @pytest.mark.asyncio
+    async def test_async_get_queue_snapshot(self, mock_upnp_device, mock_session):
+        """Test queue browse data is normalized for browse consumers."""
+        device = WiimDevice(mock_upnp_device, mock_session)
+        device.async_get_queue_items = AsyncMock(
+            return_value=[
+                {"SourceName": "Pandora2 Station"},
+                {"uri": "1", "name": "Track One", "image_url": "art1.jpg"},
+                {"uri": "2", "name": "Track Two"},
+            ]
+        )
+        device.async_set_AVT_cmd = AsyncMock(
+            return_value={
+                "PlayMedium": "SONGLIST-NETWORK",
+                "TrackSource": "Pandora2",
+            }
+        )
+
+        snapshot = await device.async_get_queue_snapshot()
+
+        assert snapshot.is_active is True
+        assert snapshot.source_name == "Pandora2 Station"
+        assert len(snapshot.items) == 2
+        assert snapshot.items[0].queue_index == 1
+        assert snapshot.items[0].title == "Track One"

--- a/tests/wiim/test_wiim_device.py
+++ b/tests/wiim/test_wiim_device.py
@@ -5,11 +5,13 @@ from wiim.wiim_device import WiimDevice
 from wiim.endpoint import WiimApiEndpoint
 from wiim.consts import (
     DeviceAttribute,
+    LoopMode,
     PlayerAttribute,
     PlayingStatus,
     WiimHttpCommand,
     InputMode,
 )
+from wiim.models import WiimRepeatMode
 
 
 @patch("wiim.wiim_device.AiohttpNotifyServer", MagicMock())
@@ -132,3 +134,49 @@ class TestWiimDevice:
         assert device.parse_duration("00:02:30.123") == 150
         assert device.parse_duration(None) == 0
         assert device.parse_duration("NOT_IMPLEMENTED") == 0
+
+    def test_supported_modes_from_model(self, mock_upnp_device, mock_session):
+        """Test supported input/output modes are derived by the SDK."""
+        device = WiimDevice(mock_upnp_device, mock_session)
+
+        assert InputMode.LINE_IN.display_name in device.supported_input_modes  # type: ignore[attr-defined]
+        assert "Optical Out" in device.supported_output_modes
+
+    def test_current_media_uses_normalized_metadata(
+        self, mock_upnp_device, mock_session
+    ):
+        """Test current media metadata is exposed through a typed helper."""
+        device = WiimDevice(mock_upnp_device, mock_session)
+        device.current_track_info = {
+            "title": "Test Song",
+            "artist": "Test Artist",
+            "album": "Test Album",
+            "uri": "https://example.com/song.mp3",
+            "albumArtURI": "https://example.com/art.jpg",
+        }
+        device.current_track_duration = 210
+        device.current_position = 15
+
+        media = device.current_media
+
+        assert media is not None
+        assert media.title == "Test Song"
+        assert media.artist == "Test Artist"
+        assert media.album == "Test Album"
+        assert media.uri == "https://example.com/song.mp3"
+        assert media.image_url == "https://example.com/art.jpg"
+        assert media.duration == 210
+        assert media.position == 15
+        assert device.album_art_uri == "https://example.com/art.jpg"
+
+    def test_loop_state_helpers(self, mock_upnp_device, mock_session):
+        """Test normalized loop mode helpers."""
+        device = WiimDevice(mock_upnp_device, mock_session)
+        device.loop_mode = LoopMode.SHUFFLE_ENABLE_REPEAT_ONE
+
+        assert device.loop_state.repeat == WiimRepeatMode.ONE
+        assert device.loop_state.shuffle is True
+        assert (
+            WiimDevice.build_loop_mode(WiimRepeatMode.ALL, shuffle=False)
+            == LoopMode.SHUFFLE_DISABLE_REPEAT_ALL
+        )


### PR DESCRIPTION
## Summary
Move more WiiM-specific setup and protocol handling out of Home Assistant and into the library.

This PR adds higher-level helpers for device creation, probing, media state, browse data, transport capabilities, and group state so the HA integration can consume normalized SDK APIs instead of raw UPnP and HTTP details.

## What changed
- add discovery and setup helpers:
  - `verify_wiim_device`
  - `async_create_http_api_endpoint`
  - `async_create_wiim_device`
  - `async_probe_wiim_device`
- add typed SDK models in `wiim.models`:
  - `WiimMediaMetadata`
  - `WiimLoopState`
  - `WiimTransportCapabilities`
  - `WiimPreset`
  - `WiimQueueItem`
  - `WiimQueueSnapshot`
  - `WiimGroupSnapshot`
  - `WiimProbeResult`
- extend `WiimDevice` with:
  - `supported_input_modes`
  - `supported_output_modes`
  - `current_media`
  - `loop_state`
  - `build_loop_mode(...)`
  - `async_get_transport_capabilities()`
  - `async_get_presets()`
  - `async_get_queue_snapshot()`
- extend `WiimController` with typed group helpers:
  - `get_group_snapshot()`
  - `get_command_target_udn()`
- make `WiimApiEndpoint` optionally own and close its session
- close the owned HTTP API session from `WiimDevice.disconnect()`
- update the CLI to use the same device creation path as the new helpers

## Why
The Home Assistant integration currently duplicates a lot of WiiM-specific logic:
- UPnP device construction
- HTTP endpoint setup
- model capability lookup
- media metadata shaping
- browse parsing
- group role parsing
- transport capability parsing from `MEDIA_INFO`

Moving that logic here makes the integration thinner and gives other consumers a cleaner API surface.

## Verification
- `ruff check`
- `pytest`
- current branch result: `42 passed`

## Follow-up
This is intended to be consumed by the Home Assistant WiiM integration in a follow-up dependency bump.
