### PR TITLE
Fix volume change propagating to followers when invoked on multiroom leader

### DIFF
--- a/src/wiim/consts.py
+++ b/src/wiim/consts.py
@@ -26,6 +26,7 @@ class WiimHttpCommand(StrEnum):
     PLAYER_STATUS = "getPlayerStatusEx"
     SWITCH_MODE = "setPlayerCmd:switchmode:{}"
     PLAY = "setPlayerCmd:play:{}"
+    SET_VOLUME = "setPlayerCmd:vol:{}"
     MULTIROOM_LIST = "multiroom:getSlaveList"
     MULTIROOM_UNGROUP = "multiroom:Ungroup"
     MULTIROOM_LEAVEGROUP = "multiroom:LeaveGroup"
@@ -215,7 +216,7 @@ class AudioOutputHwMode(IntFlag):
 
 
 CMD_TO_MODE_MAP: dict[int, AudioOutputHwMode] = {
-    member.cmd: member # type: ignore[attr-defined]
+    member.cmd: member  # type: ignore[attr-defined]
     for member in AudioOutputHwMode  # type: ignore[attr-defined]
 }
 

--- a/src/wiim/wiim_device.py
+++ b/src/wiim/wiim_device.py
@@ -1392,12 +1392,7 @@ class WiimDevice:
                 "Attempted to set volume outside 0-100 range: %s", volume_percent
             )
             volume_percent = max(0, min(100, volume_percent))
-        await self._invoke_upnp_action(
-            "RenderingControl",
-            "SetVolume",
-            Channel="Master",
-            DesiredVolume=volume_percent,
-        )
+        await self._http_command_ok(WiimHttpCommand.SET_VOLUME, str(volume_percent))
         self.volume = volume_percent
 
     async def async_set_mute(self, mute: bool) -> None:


### PR DESCRIPTION
This PR aims to fix an issue where using `WiimDevice.async_set_volume()` seems to change the volume of all followers when executed on a multiroom leader

On a device that is a multiroom leader, the firmware interprets this as a group volume command and propagates the change to all followers. Setting the volume of a follower works correctly, it only changes the volume of the follower.

**Reproduction steps**

1. Two WiiM speakers, both visible to the SDK.
2. Group speaker B into speaker A (A becomes leader).
3. Call device_A.async_set_volume(40).
4. Expected: A's volume is 40, B unchanged.
5. Actual: Both A and B are set to 40.

Note: Using the WiiM native app seems to change the volume as expected.

It seems that changing from the upnp to the http api seems to give us the expected behaviour. 